### PR TITLE
fix: exclude parse-uuid

### DIFF
--- a/src/system_lacinia/resolvers_util.clj
+++ b/src/system_lacinia/resolvers_util.clj
@@ -1,4 +1,5 @@
 (ns system-lacinia.resolvers-util
+  (:refer-clojure :exclude [parse-uuid])
   (:import (java.text SimpleDateFormat)
            (java.util TimeZone
                       UUID)))


### PR DESCRIPTION
Clojure 1.11 added a `parse-uuid` function. When using this library on 1.11+, you will receive a warning that looks like this. 

```
WARNING: parse-uuid already refers to: #'clojure.core/parse-uuid in namespace: system-lacinia.resolvers-util, being replaced by: #'system-lacinia.resolvers-util/parse-uuid
```

Excluding `parse-uuid` removes this warning. 

An alternative would be to require 1.11+ to use this library and defer to the `clojure.core/parse-uuid` function. I opted not to do that to since `clojure.core/parse-uuid` returns nil on exceptions and `system-lacinia.resolvers-util/parse-uuid` will throw. 